### PR TITLE
Update Action for GitHub enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ where
 3. <PRJ_ID> is the ID of a project to which you are sending the test results.
 
 ### For Github Enterprise
-Depending on the scope of the Github token provided by default to the action, two tokens may be required for this action:
+Depending on the scope of the Github token provided by default to the workflow, two tokens may be required for this action:
 
 ```yaml
       - uses: allure-framework/setup-allurectl@v1

--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ where
 2. `${{ secret.ALLURE_TOKEN }}` is the personal API token created in your profile of Allure TestOps. You need to save API token under `/settings/secrets/actions` as a secret `ALLURE_TOKEN` in your GitHub repository and use it as the reference to the created secret – `${{ secret.ALLURE_TOKEN }}`. Having this parameter saved as plain text in the  workflow is a bad-bad-bad idea.
 3. <PRJ_ID> is the ID of a project to which you are sending the test results.
 
+### For Github Enterprise
+Depending on the scope of the Github token provided by default to the action, two tokens may be required for this action:
+
+```yaml
+      - uses: allure-framework/setup-allurectl@v1
+        with: 
+          allure-endpoint: https://ALURE_TESTOPS_URL
+          allure-token: ${{ secret.ALLURE_TOKEN }}
+          allure-project-id: <PRJ_ID>
+          github-token: ${{ secret.GITHUB_TOKEN }}
+          github-workflow-token: ${{ secret.GITHUB_WORKFLOW_TOKEN }}
+```
+where 
+1. `${{ secret.GITHUB_TOKEN }}` allows access to public Github
+2. `${{ secret.GITHUB_WORKFLOW_TOKEN }}` allows access to information from the current workflow in Github Enterprise
+
 ### Use allurectl to upload the test results to Allure TestOps
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,11 @@ inputs:
     description: 'The ID of a project on the Allure TestOps side to which allurectl must send the test results'
     required: false
   github-token:
-    description: The GitHub token used to create an authenticated client
+    description: 'The GitHub token used to create an authenticated client to call https://api.github.com.'
+    default: ${{ github.token }}
+    required: false
+  github-workflow-token:
+    description: 'The GitHub token used to create an authenticated client to access Workflow metadata.'
     default: ${{ github.token }}
     required: false
 runs:

--- a/src/install.ts
+++ b/src/install.ts
@@ -70,7 +70,7 @@ export async function testTool(cmd: string, args: string[]) {
 }
 
 export async function setUpTool() {
-  const github_token = core.getInput('github-token', {required: true})
+  const github_token = core.getInput('github-workflow-token', {required: true})
   const client: ClientType = github.getOctokit(github_token)
 
   const owner = github.context.repo.owner
@@ -91,7 +91,8 @@ export async function setUpTool() {
 
 export async function getVersion(inputVersion: string): Promise<string> {
   const github_token = core.getInput('github-token', {required: true})
-  const client: ClientType = github.getOctokit(github_token)
+
+  const client: ClientType = github.getOctokit(github_token, {baseUrl: "https://api.github.com"})
 
   if (inputVersion && inputVersion !== 'latest') {
     const response = await client.rest.repos.getReleaseByTag({


### PR DESCRIPTION
# Update Action for Use on GitHub Enterprise

Currently the action doesn't seem to be useable for Workflows running on GitHub Enterprise. This is because:

1. getVersion relies on Oktokit defaulting the baseUrl. In Enterprise, this baseUrl appears to be defaulted to the enterprise URL rather than public GitHub.
2. The GitHub token provided by a Workflow may not be able to authenticate with the GitHub API on https://api.github.com/ if it limited by scope - this is needed by getVersion()
3. The token needed by setUpTool() may therefore need to be different from the token used by getVersion().

Proposed changes:

1. Hardcode the GitHub API URL to get releases by tag so it doesn't default to the Enterprise URL
2. Add an additional Action input to set a different token used by the setUpTool function to set Allure job metadata. This is defaulted to ${{ github.token }} to avoid regressions.