### PR TITLE
Bug Fix - Allow For Reruns of A Workflow

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -85,7 +85,7 @@ export async function setUpTool() {
   addInputVariableToEnv('allure-project-id', 'ALLURE_PROJECT_ID')
   core.exportVariable(
     'ALLURE_JOB_UID',
-    `${owner}/${repo}/actions/workflows/${data.data.workflow_id}`
+    `${owner}/${repo}/actions/workflows/${data.data.workflow_id}/${data.data.run_attempt}`
   )
 }
 


### PR DESCRIPTION
## Description - Bug Fix

Currently, rerunning a workflow using this action results in the following error from the Allure servers:
```
Cannot upload results to a closed launch
```

This can be resolved by making the `ALLURE_JOB_UID` unique by appending the `run_attempt` of the workflow:

```javascript
  core.exportVariable(
    'ALLURE_JOB_UID',
    `${owner}/${repo}/actions/workflows/${data.data.workflow_id}/${data.data.run_attempt}`
  )
```